### PR TITLE
Make the chat header dark blue

### DIFF
--- a/src/Components/Homepage/ChatHeader.tsx
+++ b/src/Components/Homepage/ChatHeader.tsx
@@ -51,7 +51,7 @@ const Container = styled.div<ContainerProps>`
 	align-items: center;
 	justify-content: space-between;
 	height: 80px;
-	background-color: ${({ theme }) => theme.headerMenuColor};
+	background-color: #003399;
 	cursor: pointer;
 	${({ $profile }) =>
 		$profile &&
@@ -71,7 +71,7 @@ const Label = styled.label<ContainerProps>`
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	background-color: ${({ theme }) => theme.headerMenuColor};
+	background-color: #003399;
 	width: 100%;
 	cursor: pointer;
 	${({ $profile }) =>


### PR DESCRIPTION


This pull request changes the background color of the chat header from the default theme color to a dark blue (#003399). The change was made in the file src/Components/Homepage/ChatHeader.tsx, where the background color was updated from ${({ theme }) => theme.headerMenuColor}; to #003399.