### PR TITLE
Make the profile picture square in the chat header

### DIFF
--- a/src/Components/Homepage/ChatHeader.tsx
+++ b/src/Components/Homepage/ChatHeader.tsx
@@ -32,7 +32,7 @@ const ChatHeader = ({ avatar_url, username, profile }: Props) => {
 			<Label htmlFor="profile">
 				<Flex>
 					<ImageContainer>
-						<img src={avatar_url !== null ? avatar_url : Picture} alt="profile picture" />
+						<img src={avatar_url !== null ? avatar_url : Picture} alt="profile picture" style={{ width: '50px', height: '50px', objectFit: 'cover' }} />
 					</ImageContainer>
 					<Username>{username}</Username>
 				</Flex>


### PR DESCRIPTION


This pull request makes the profile picture square in the chat header.

The following files were modified:

- src/Components/Homepage/ChatHeader.tsx

The following changes were made:

- Added `style={{ width: '50px', height: '50px', objectFit: 'cover' }}` to the `<img>` tag on line 34 of src/Components/Homepage/ChatHeader.tsx. This ensures that the profile picture is displayed as a square.