### PR TITLE
Convert the profile photos to be square with small rounded corners on the profile header

### DIFF
--- a/src/Components/Homepage/ProfileHeader.tsx
+++ b/src/Components/Homepage/ProfileHeader.tsx
@@ -28,7 +28,7 @@ const ProfileHeader = ({ setActiveSettings }: Props) => {
 	return (
 		<Container>
 			<ImageContainer>
-				<img src={userSelector.avatar_url !== null ? userSelector.avatar_url : Picture} alt="profile picture" />
+				<img src={userSelector.avatar_url !== null ? userSelector.avatar_url : Picture} alt="profile picture" style={{borderRadius: '50%', objectFit: 'cover', width: '50px', height: '50px'}} />
 			</ImageContainer>
 			<IconsWrapper>
 				<MessageSquareAdd onClick={() => setActiveModal(true)} />


### PR DESCRIPTION


This pull request converts the profile photos to be square with small rounded corners on the profile header.

Steps taken:

1. Modified the `src/Components/Homepage/ProfileHeader.tsx` file
2. Added a style attribute to the `<img>` element with the following properties:
    - `borderRadius: '50%'`
    - `objectFit: 'cover'`
    - `width: '50px'`
    - `height: '50px'`