### PR TITLE
How can I change the profile header to remove the profile photo?

### DIFF
--- a/src/Components/Homepage/ProfileHeader.tsx
+++ b/src/Components/Homepage/ProfileHeader.tsx
@@ -28,7 +28,7 @@ const ProfileHeader = ({ setActiveSettings }: Props) => {
 	return (
 		<Container>
 			<ImageContainer>
-				<img src={userSelector.avatar_url !== null ? userSelector.avatar_url : Picture} alt="profile picture" />
+				<img src={Picture} alt="profile picture" />
 			</ImageContainer>
 			<IconsWrapper>
 				<MessageSquareAdd onClick={() => setActiveModal(true)} />


### PR DESCRIPTION


This pull request removes the profile photo from the profile header.

**Files modified:**
- src/Components/Homepage/ProfileHeader.tsx

**Steps taken:**
1. Opened src/Components/Homepage/ProfileHeader.tsx
2. Changed line 30 from `<img src={userSelector.avatar_url !== null ? userSelector.avatar_url : Picture} alt="profile picture" />` to `<img src={Picture} alt="profile picture" />`