### PR TITLE
How can I remove the profile picture from the profile header?

### DIFF
--- a/src/Components/Homepage/ProfileHeader.tsx
+++ b/src/Components/Homepage/ProfileHeader.tsx
@@ -28,7 +28,7 @@ const ProfileHeader = ({ setActiveSettings }: Props) => {
 	return (
 		<Container>
 			<ImageContainer>
-				<img src={userSelector.avatar_url !== null ? userSelector.avatar_url : Picture} alt="profile picture" />
+				// <img src={userSelector.avatar_url !== null ? userSelector.avatar_url : Picture} alt="profile picture" />
 			</ImageContainer>
 			<IconsWrapper>
 				<MessageSquareAdd onClick={() => setActiveModal(true)} />


### PR DESCRIPTION


This pull request removes the profile picture from the profile header.

**Files modified:**
- src/Components/Homepage/ProfileHeader.tsx

**Steps taken:**
- Commented out the line of code that renders the profile picture in ProfileHeader.tsx.