### PR TITLE
Autogenerated PR

### DIFF
--- a/src/Components/Homepage/ProfileHeader.tsx
+++ b/src/Components/Homepage/ProfileHeader.tsx
@@ -71,10 +71,9 @@ const ImageContainer = styled.div`
 	height: 50px;
 	width: 50px;
 	& img {
-		border-radius: 50%;
-		height: 100%;
-		width: 100%;
-		object-fit: cover;
+		height: 50px;
+		width: 50px;
+		object-fit: contain;
 	}
 `
 


### PR DESCRIPTION
This PR makes the corners of the profile image in the profile header square.

In the file src/Components/Homepage/ProfileHeader.tsx, the following changes were made:

- The line `border-radius: 50%;` was removed from the `img` element.
- The `height` and `width` of the `img` element were set to `50px`.
- The `object-fit` property of the `img` element was set to `contain`.

This ensures that the profile image is a square and is not stretched or distorted.